### PR TITLE
Add support for generating test case name based on case arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,17 @@ from parametrization import Parametrization
 def test_somthing(actual, expected):
     assert actual == expected
 ```
+### Generate name based on arguments
+```python
+from parametrization import Parametrization
+
+@Parametrization.name_factory(lambda actual, expected: '{}=={}'.format(actual, expected))
+@Parametrization.case(actual=1, expected=1)
+@Parametrization.case(actual=2, expected=2)
+@Parametrization.case('special-name', actual=3, expected=3)
+def test_somthing(actual, expected):
+    assert actual == expected
+```
+
+As can be seen from the example, you can also give explicit name for a case
+even if you are using name factory.

--- a/tests/test_parametrization.py
+++ b/tests/test_parametrization.py
@@ -14,3 +14,17 @@ from parametrization import Parametrization
 def test_default_parameters(a, b):
     assert a == 'a' or a == 2
     assert b == 3
+
+
+@Parametrization.autodetect_parameters()
+@Parametrization.name_factory(lambda a, b: '{}-{}'.format(a, b))
+@Parametrization.case(
+    a='A',
+    b='B',
+)
+@Parametrization.case(
+    a='C',
+    b='D',
+)
+def test_name_as_callable(a, b):
+    assert a != b


### PR DESCRIPTION
Some times one parameter (or a combination of parameters) describe the test case. In these cases I have found out that I want to duplicate parameter values to the name.

This PR adds support for name factory, i.e. a callable that receives all the case parameters and returns the name for the case.