### PR TITLE
Allow applying markers via case(..., marks=...)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ pip install pytest-parametrization
 ## How to use
 ### Explicit parameters
 ```python
+import pytest
 from parametrization import Parametrization
  
 @Parametrization.parameters("actual", "expected")
@@ -18,9 +19,15 @@ from parametrization import Parametrization
 @Parametrization.case("some_case_2", 1, expected=1)
 @Parametrization.case("some_case_3", 2, 2)
 @Parametrization.case("some_case_4", 3, 3)
+@Parametrization.case("some_case_5", 4, 5, marks=pytest.mark.xfail)
 def test_somthing(actual, expected):
     assert actual == expected
 ```
+
+Note that both the `name` and `marks` keyword arguments are reserved for
+special purposes as shown above, so parameters with these names must have their
+values provided as positional arguments.
+
 ### Auto-detect parameters
 ```python
 from parametrization import Parametrization


### PR DESCRIPTION
My suggestion for how to implement #7 that I mentioned at the end of that issue. Adds a new `marks` parameter to `Parametrization.case()`, in analogy to [pytest's own `pytest.param(..., marks=...)`](https://docs.pytest.org/en/7.1.x/reference/reference.html).

As I wrote in #7, this solution has the drawback of introducing a new reserved keyword argument for `case()`, but I still find it so much more ergonomic than the alternatives that to me it would be worth it. Might need to wait until the next major release though because it should be considered a breaking change...

Thoughts?